### PR TITLE
Enhancement/likeableperson/2

### DIFF
--- a/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
+++ b/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
@@ -1,0 +1,19 @@
+package com.ll.gramgram.base.appConfig;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+
+    @Getter
+    private static long likeablePersonFromMax;
+
+
+    @Value("${custom.likeablePerson.from.max}")
+    public void setLikeablePersonFromMax(long likeablePersonFromMax) {
+        AppConfig.likeablePersonFromMax = likeablePersonFromMax;
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -39,6 +39,7 @@ public class LikeablePersonController {
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
         if (createRsData.isFail()) {
+            log.info("호감표시 실패");
             return rq.historyBack(createRsData);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -49,4 +49,8 @@ public class LikeablePerson {
             default -> "능력";
         };
     }
+
+    public void modifyAttractiveTypCode(int attractiveTypeCode) {
+        this.attractiveTypeCode = attractiveTypeCode;
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.likeablePerson.service;
 
+import com.ll.gramgram.base.appConfig.AppConfig;
 import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
@@ -31,6 +32,11 @@ public class LikeablePersonService {
 
         if (member.getInstaMember().getUsername().equals(username)) {
             return RsData.of("F-1", "본인은 호감상대로 저장할 수 없습니다.");
+        }
+
+        if(fromInstaMember.getFromLikeablePeople().size() >= AppConfig.getLikeablePersonFromMax()){
+            return RsData.of("F-1","%d명 이상에게 호감을 표시할 수 없습니다.".formatted(AppConfig.getLikeablePersonFromMax()));
+
         }
 
         if (!canLike(fromInstaMember, toInstaMember)) {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,6 +33,11 @@ public class LikeablePersonService {
             return RsData.of("F-1", "본인은 호감상대로 저장할 수 없습니다.");
         }
 
+        if (!canLike(fromInstaMember, toInstaMember)) {
+            log.info("중복 호감 표시");
+            return RsData.of("F-1", "이미 호감을 표시한 상대입니다.");
+        }
+
         LikeablePerson likeablePerson = LikeablePerson.builder()
                 .fromInstaMember(fromInstaMember)
                 .fromInstaMemberUsername(fromInstaMember.getUsername())
@@ -47,6 +53,22 @@ public class LikeablePersonService {
 
 
         return RsData.of("S-1", "입력하신 인스타 유저(%s)를 호감상대로 등록되었습니다.".formatted(username), likeablePerson);
+
+    }
+
+    private boolean canLike(InstaMember fromInstaMember, InstaMember toInstaMember) {
+        List<LikeablePerson> fromLikeablePeople = fromInstaMember.getFromLikeablePeople();
+
+        LikeablePerson likeablePerson = fromLikeablePeople.stream()
+                .filter(e -> e.getToInstaMember().getUsername().equals(toInstaMember.getUsername()))
+                .findFirst()
+                .orElse(null);
+
+        if (likeablePerson != null) {
+            return false;
+        }
+
+        return true;
 
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,8 @@ logging:
 jasypt:
   encryptor:
     bean: jasyptStringEncryptor
+
+custom:
+  likeablePerson:
+      from:
+        max: 10

--- a/src/main/resources/templates/common/js.html
+++ b/src/main/resources/templates/common/js.html
@@ -14,5 +14,4 @@
         localStorage.setItem(localStorageKeyAboutHistoryBackErrorMsg, historyBackErrorMsg);
     }
     history.back();
-
 </script>

--- a/src/main/resources/templates/common/js.html
+++ b/src/main/resources/templates/common/js.html
@@ -12,5 +12,7 @@
 
     if (localStorageKeyAboutHistoryBackErrorMsg && localStorageKeyAboutHistoryBackErrorMsg.trim().length > 0) {
         localStorage.setItem(localStorageKeyAboutHistoryBackErrorMsg, historyBackErrorMsg);
+    }
+    history.back();
 
 </script>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -95,6 +95,13 @@
         if ( localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg) ) {
             toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
             localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+            } else if ( !document.referrer ) {
+            const localStorageKeyAboutHistoryBackErrorMsg = "historyBackErrorMsg___null";
+
+            if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
+                toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
+                localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+            }
         }
     });
 </script>


### PR DESCRIPTION
같은 상대에게 중복 호감 표시가 되지 않게 추가
- 호감 표시 이유가 같은 경우에만 중복 호감이라고 명시되며 실패하게
- 호감 표시 이유가 다른 경우에는 수정되게

호감 상대는 최대 10명으로 제한을 걸어주게 구현


Close #15 